### PR TITLE
Plural/Singular Wording for GitHub data section

### DIFF
--- a/main.py
+++ b/main.py
@@ -409,8 +409,10 @@ def get_short_info(github):
     else:
         string += "> 🚫 Not opted to Hire\n > \n"
 
-    string += '> 📜 ' + str(public_repo) + ' Public Repository \n > \n'
-    string += '> 🔑 ' + str(private_repo) + ' Owned Private Repository \n\n'
+    string += '> 📜 ' + str(public_repo) + " Public Repositor"
+    string += 'ies \n > \n' if public_repo > 1 else 'y \n > \n'
+    string += '> 🔑 ' + str(private_repo) + " Owned Private Repositor"
+    string += 'ies \n\n' if private_repo > 1 else 'y \n > \n'
 
     print(string)
     return string


### PR DESCRIPTION
I've actually just tried this action a few minutes ago, and I think it's really cool. But for the ”My Github data’ section:
![8F0BF9D8-F2AA-4E9C-977D-2FF7C0804C54](https://user-images.githubusercontent.com/50042066/89138960-e1869080-d56f-11ea-8395-cb42def7b690.jpeg)

The wording with more than 1 repository is a bit weird, and would be better if it was ”repositories”, so I updated the code so that when it's >1 the word would be plural, if not, singular

“repository” for 1
“repositories” for >1

![A064C387-26FA-4FF3-B62B-E363FBB8BDA0](https://user-images.githubusercontent.com/50042066/89139067-227ea500-d570-11ea-9a3f-dbe78c23df61.jpeg)

I have not tested the changes as a GitHub action because I think it’s a really small change, but I did tested the parts I changed with a python interpreter.

Super sorry because I know I have a bad commit message 