### PR TITLE
docs: add link to issue #23 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
->Looking For Translation to different languages #23
+> Looking For Translation to different languages [#23](https://github.com/anmol098/waka-readme-stats/issues/23)
 
 # Dev Metrics in Readme with added feature flags 🎌
 


### PR DESCRIPTION
On the first line, you painted out to ”looking to looking for translations” with issue number but without link, so I added a link so people can click on it to view the issue