### PR TITLE
Fake author for commits

### DIFF
--- a/loc.py
+++ b/loc.py
@@ -81,10 +81,11 @@ class LinesOfCode:
 
     def pushChart(self):
         repo = self.g.get_repo(f"{self.username}/{self.username}")
+        committer = InputGitAuthor('readme-bot', 'readme-bot@example.com')
         with open('bar_graph.png', 'rb') as input_file:
             data = input_file.read()
         try:
             contents = repo.get_contents("charts/bar_graph.png")
-            repo.update_file(contents.path, "Charts Added", data, contents.sha)
+            repo.update_file(contents.path, "Charts Updated", data, contents.sha, committer)
         except Exception as e:
-            repo.create_file("charts/bar_graph.png", "Initial Commit", data)
+            repo.create_file("charts/bar_graph.png", "Charts Added", data, committer)

--- a/loc.py
+++ b/loc.py
@@ -2,7 +2,7 @@ import re
 import os
 import base64
 import requests
-from github import Github
+from github import Github, InputGitAuthor
 import datetime
 from string import Template
 import matplotlib.pyplot as plt

--- a/loc.py
+++ b/loc.py
@@ -86,6 +86,6 @@ class LinesOfCode:
             data = input_file.read()
         try:
             contents = repo.get_contents("charts/bar_graph.png")
-            repo.update_file(contents.path, "Charts Updated", data, contents.sha, committer)
+            repo.update_file(contents.path, "Charts Updated", data, contents.sha, committer=committer)
         except Exception as e:
-            repo.create_file("charts/bar_graph.png", "Charts Added", data, committer)
+            repo.create_file("charts/bar_graph.png", "Charts Added", data, committer=committer)

--- a/main.py
+++ b/main.py
@@ -489,7 +489,9 @@ if __name__ == '__main__':
         new_readme = generate_new_readme(stats=waka_stats, readme=rdmd)
         if new_readme != rdmd:
             repo.update_file(path=contents.path, message='Updated with Dev Metrics',
-                             content=new_readme, sha=contents.sha, branch='master')
+                             content=new_readme, sha=contents.sha, branch='master',
+                             committer=g.InputGitAuthor("readme-bot", 
+                             "readme-bot@example.com"))
             print("Readme updated")
     except Exception as e:
         traceback.print_exc()

--- a/main.py
+++ b/main.py
@@ -487,7 +487,7 @@ if __name__ == '__main__':
         waka_stats = get_stats(g)
         rdmd = decode_readme(contents.content)
         new_readme = generate_new_readme(stats=waka_stats, readme=rdmd)
-        committer = g.InputGitAuthor('readme-bot', 'readme-bot@example.com')
+        committer = InputGitAuthor('readme-bot', 'readme-bot@example.com')
         if new_readme != rdmd:
             repo.update_file(path=contents.path, message='Updated with Dev Metrics',
                              content=new_readme, sha=contents.sha, branch='master',

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import base64
 from pytz import timezone
 import pytz
 import requests
-from github import Github, GithubException
+from github import Github, GithubException, InputGitAuthor
 import datetime
 from string import Template
 from loc import LinesOfCode
@@ -461,7 +461,7 @@ def get_stats(github):
 
 
 def decode_readme(data: str):
-    '''Decode the contets of old readme'''
+    '''Decode the contents of old readme'''
     decoded_bytes = base64.b64decode(data)
     return str(decoded_bytes, 'utf-8')
 
@@ -487,11 +487,11 @@ if __name__ == '__main__':
         waka_stats = get_stats(g)
         rdmd = decode_readme(contents.content)
         new_readme = generate_new_readme(stats=waka_stats, readme=rdmd)
+        committer = g.InputGitAuthor('readme-bot', 'readme-bot@example.com')
         if new_readme != rdmd:
             repo.update_file(path=contents.path, message='Updated with Dev Metrics',
                              content=new_readme, sha=contents.sha, branch='master',
-                             committer=g.InputGitAuthor("readme-bot", 
-                             "readme-bot@example.com"))
+                             committer=committer)
             print("Readme updated")
     except Exception as e:
         traceback.print_exc()


### PR DESCRIPTION
This is an implementation of the feature request in #49.

It follows the same method as [this repository](https://github.com/jamesgeorge007/github-activity-readme) in that it simply gives a fake email and username, thus preventing the commits from being attributed to your account and needlessly filling up your commit chart.