### PR TITLE
Add Arduino to colors.json

### DIFF
--- a/colors.json
+++ b/colors.json
@@ -71,6 +71,10 @@
         "color": "#aa2afe",
         "url": "https://github.com/trending?l=Arc"
     },
+    "Arduino": {
+        "color": null,
+        "url": "https://github.com/trending?l=Arduino"
+    },
     "ASP": {
         "color": "#6a40fd",
         "url": "https://github.com/trending?l=ASP"


### PR DESCRIPTION
The missing `Arduino` key causes the script to fail https://github.com/AMR-KELEG/AMR-KELEG/runs/1064461257?check_suite_focus=true