### PR TITLE
fix: pin python version to 3.8 and nodejs to 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM nikolaik/python-nodejs:python3.8-nodejs12-alpine
-
-RUN apk update && apk add --no-cache gcc
+FROM nikolaik/python-nodejs:python3.8-nodejs12
 
 # Install dependencies.
 ADD requirements.txt /requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:latest
+FROM nikolaik/python-nodejs:python3.8-nodejs12-alpine
 
 # Install dependencies.
 ADD requirements.txt /requirements.txt
@@ -16,4 +16,3 @@ RUN npm -g config set user root
 RUN npm install -g vega-lite vega-cli canvas
 
 ENTRYPOINT ["python", "/main.py"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM nikolaik/python-nodejs:python3.8-nodejs12-alpine
 
+RUN apk update && apk add --no-cache gcc
+
 # Install dependencies.
 ADD requirements.txt /requirements.txt
 ADD main.py /main.py


### PR DESCRIPTION
This fixes #113 by pinning the python version to 3.8.
I tried the alpine image first but since GitHub Actions doesn't cache action builds, it's not worth the run time when gcc is required.
Downloading larger images is significantly faster than rebuilding the image on and on.
I've tested it [here](https://github.com/matfax/matfax/runs/1226060531?check_suite_focus=true) and it works again.