### PR TITLE
Change Plural Case

### DIFF
--- a/main.py
+++ b/main.py
@@ -369,9 +369,12 @@ def generate_language_per_repo(result):
     most_language_repo = sorted_labels[0]
     for label in sorted_labels:
         percent = round(language_count[label]['count'] / total * 100, 2)
+        extension = "repos"
+        if language_count[label]['count'] == 1:
+            extension = "repo"
         data.append({
             "name": label,
-            "text": str(language_count[label]['count']) + " repos",
+            "text": str(language_count[label]['count']) + extension,
             "percent": percent
         })
 

--- a/main.py
+++ b/main.py
@@ -369,9 +369,9 @@ def generate_language_per_repo(result):
     most_language_repo = sorted_labels[0]
     for label in sorted_labels:
         percent = round(language_count[label]['count'] / total * 100, 2)
-        extension = "repos"
+        extension = " repos"
         if language_count[label]['count'] == 1:
-            extension = "repo"
+            extension = " repo"
         data.append({
             "name": label,
             "text": str(language_count[label]['count']) + extension,


### PR DESCRIPTION
In my readme, I noticed that I had one repo which is mainly CSS. Waka readme stats stated CSS --- 1 repos. I made it so if it is only one repo to change it to not be plural (to CSS --- 1 repo).

<img width="586" alt="Screenshot 2020-10-12 at 12 46 26" src="https://user-images.githubusercontent.com/65845077/95716351-f9be0e80-0c88-11eb-9bad-f5aaa3b513f2.png">
