### PR TITLE
feat: calculate loc using commit data

### DIFF
--- a/main.py
+++ b/main.py
@@ -383,18 +383,10 @@ def generate_language_per_repo(result):
 
 
 def get_line_of_code():
-    result = run_query(createContributedRepoQuery.substitute(username=username))
-    nodes = result["data"]["user"]["repositoriesContributedTo"]["nodes"]
-    repos = [d for d in nodes if d['isFork'] is False]
-    total_loc = 0
-    for repository in repos:
-        try:
-            time.sleep(0.7)
-            datas = run_v3_api(get_loc_url.substitute(owner=repository["owner"]["login"], repo=repository["name"]))
-            for data in datas:
-                total_loc = total_loc + data[1] - data[2]
-        except Exception as execp:
-            print(execp)
+    repositoryList = run_query(repositoryListQuery.substitute(username=username, id=id))
+    loc = LinesOfCode(id, username, ghtoken, repositoryList)
+    yearly_data = loc.calculateLoc()
+    total_loc = sum([yearly_data[year][quarter][lang] for year in yearly_data for quarter in yearly_data[year] for lang in yearly_data[year][quarter]])
     return humanize.intword(int(total_loc))
 
 
@@ -459,7 +451,8 @@ def get_stats(github):
 
     if showLocChart.lower() in truthy:
         loc = LinesOfCode(id, username, ghtoken, repositoryList)
-        loc.calculateLoc()
+        yearly_data = loc.calculateLoc()
+        loc.plotLoc(yearly_data)
         stats += '**' + translate['Timeline'] + '**\n\n'
         stats = stats + '![Chart not found](https://raw.githubusercontent.com/' + username + '/' + username + '/master/charts/bar_graph.png) \n\n'
 


### PR DESCRIPTION
Signed-off-by: Aadit Kamat <aadit.k12@gmail.com>

Fixes #127 

Currently, the number of lines of code displayed in the shield is not consistent with the number of lines of code displayed on the graph. 

I'm using the same method `LinesOfCode.calculateLoc` to calculate the number of lines of code in both the places. Instead of using the code frequency for a repository to calculate the lines of code (which includes contributions from others as well), I'm filtering out the commits in the repository based on username and then totaling the additions per commit, which should give a more accurate estimate of the lines of code written. 

Testing it out on my account for example, I get 16602 lines of code written since I opened up a GitHub account, which I feel is closer to the actual value as compared to 29.2 million lines of code that shows up currently on my README. Also, the timeline graph on my README shows LOC added all the way back from 2015, when in fact I set up a GitHub account only in 2017. This is because I had contributed to a repository that was first created on March 2015. Using this new method avoids such issues.