### PR TITLE
fix: filter commits by author for loc calculation

### DIFF
--- a/loc.py
+++ b/loc.py
@@ -56,24 +56,23 @@ class LinesOfCode:
             return 3
         elif month >= 10 and month <= 12:
             return 4
-        
+
     def getCommitStat(self, repoDetails, yearly_data):
-        allCommitsEndPoint = 'https://api.github.com/repos/' + repoDetails['nameWithOwner'] + '/commits'
-        allCommitsResult = self.run_query_v3(allCommitsEndPoint)
+        commitsURL = 'https://api.github.com/repos/' + repoDetails['nameWithOwner'] + '/commits'
+        filteredCommitsEndPoint = commitsURL + '?author=' + self.username
+        filteredCommitsResult = self.run_query_v3(filteredCommitsEndPoint)
         # This ignores the error message you get when you try to list commits for an empty repository
-        if not type(allCommitsResult) == list:
+        if not type(filteredCommitsResult) == list:
             return
         this_year = datetime.datetime.utcnow().year
 
-        for i in range(len(allCommitsResult)):
-            author = allCommitsResult[i]["commit"]["author"]
-            if author["name"] != self.username:
-                continue
-            date = re.search(r'\d+-\d+-\d+', author["date"]).group(0)
+        for i in range(len(filteredCommitsResult)):
+            iso_date = filteredCommitsResult[i]["commit"]["author"]["date"]
+            date = re.search(r'\d+-\d+-\d+', iso_date).group(0)
             curr_year = datetime.datetime.fromisoformat(date).year
             # if  curr_year != this_year:
 
-            individualCommitEndPoint = allCommitsResult[i]["url"]
+            individualCommitEndPoint = commitsURL + '/' + filteredCommitsResult[i]["sha"]
             individualCommitResult = self.run_query_v3(individualCommitEndPoint)
 
             quarter = self.getQuarter(date)


### PR DESCRIPTION
Signed-off-by: Aadit Kamat <aadit.k12@gmail.com>

This PR revises the LOC calculation done in #144. As it turns out, the method used in #144 underestimates the lines of code. The graph that shows up in the README for my account only considers commits for 2018 using that method. I've updated the algorithm so that it gets the filtered commits using the `author` parameter in the GET request to the GitHub api for the commits data and then sums up the additions per commit. This is more time consuming but also more accurate I think. I don't have a benchmark for comparison since my Sourcerer profile shows much lesser lines of code because it includes lesser repositories in its calculation. 