### PR TITLE
Use dataframe instead of list

### DIFF
--- a/make_bar_graph.py
+++ b/make_bar_graph.py
@@ -74,8 +74,7 @@ class BarGraph:
         for language in language_df.keys():
             language_df[language] = prep_df(language_df[language], language)
 
-        df = pd.concat(list(language_df.values()))
-
+        df = pd.concat(language_df.values())
 
         chart = alt.Chart(df).mark_bar().encode(
 


### PR DESCRIPTION
Signed-off-by: Aadit Kamat <aadit.k12@gmail.com>

Fixes #148 

`pd.concat` should take in a `DataFrame` object instead of a `list` object.