### PR TITLE
Detect main branch

### DIFF
--- a/main.py
+++ b/main.py
@@ -454,7 +454,12 @@ def get_stats(github):
         yearly_data = loc.calculateLoc()
         loc.plotLoc(yearly_data)
         stats += '**' + translate['Timeline'] + '**\n\n'
-        stats = stats + '![Chart not found](https://raw.githubusercontent.com/' + username + '/' + username + '/master/charts/bar_graph.png) \n\n'
+        try:
+            github.get_repo(f'{username}/{username}').get_branch('main')
+            branch_name = 'main'
+        except GithubException:
+            branch_name = 'master'
+        stats = stats + '![Chart not found](https://raw.githubusercontent.com/' + username + '/' + username + '/' + branch_name + '/charts/bar_graph.png) \n\n'
 
     return stats
 

--- a/main.py
+++ b/main.py
@@ -454,11 +454,7 @@ def get_stats(github):
         yearly_data = loc.calculateLoc()
         loc.plotLoc(yearly_data)
         stats += '**' + translate['Timeline'] + '**\n\n'
-        try:
-            github.get_repo(f'{username}/{username}').get_branch('main')
-            branch_name = 'main'
-        except GithubException:
-            branch_name = 'master'
+        branch_name = github.get_repo(f'{username}/{username}').default_branch
         stats = stats + '![Chart not found](https://raw.githubusercontent.com/' + username + '/' + username + '/' + branch_name + '/charts/bar_graph.png) \n\n'
 
     return stats


### PR DESCRIPTION
Signed-off-by: Aadit Kamat <aadit.k12@gmail.com>

Fixes #122.

Currently, the `master` branch is used to generate the chart by default and I've added a check to see if the repository has a `main` branch. If so, the chart is rendered using the PNG file in the main branch. Otherwise, it just defaults to the `master` branch.