### PR TITLE
feat: use github-actions bot as the committer

### DIFF
--- a/loc.py
+++ b/loc.py
@@ -96,7 +96,7 @@ class LinesOfCode:
 
     def pushChart(self):
         repo = self.g.get_repo(f"{self.username}/{self.username}")
-        committer = InputGitAuthor('readme-bot', 'readme-bot@example.com')
+        committer = InputGitAuthor('readme-bot', '41898282+github-actions[bot]@users.noreply.github.com')
         with open('bar_graph.png', 'rb') as input_file:
             data = input_file.read()
         try:

--- a/main.py
+++ b/main.py
@@ -498,7 +498,7 @@ if __name__ == '__main__':
         star_me()
         rdmd = decode_readme(contents.content)
         new_readme = generate_new_readme(stats=waka_stats, readme=rdmd)
-        committer = InputGitAuthor('readme-bot', 'readme-bot@example.com')
+        committer = InputGitAuthor('readme-bot', '41898282+github-actions[bot]@users.noreply.github.com')
         if new_readme != rdmd:
             try:
                 repo.update_file(path=contents.path, message='Updated with Dev Metrics',


### PR DESCRIPTION
Since, we are using GitHub Actions anyways, it's better we use `41898282+github-actions[bot]@users.noreply.github.com` for commits, so that we can have GitHub Actions icon. Just like https://github.com/jamesgeorge007/github-activity-readme/pull/41.