### PR TITLE
Added Svelte code language

### DIFF
--- a/colors.json
+++ b/colors.json
@@ -1407,6 +1407,10 @@
 		"color": "#46390b",
 		"url": "https://github.com/trending?l=SuperCollider"
 	},
+	"Svelte": {
+		"color": "#ff3e00",
+		"url": "https://github.com/trending?l=Svelte"
+	},
 	"Swift": {
 		"color": "#ffac45",
 		"url": "https://github.com/trending?l=Swift"


### PR DESCRIPTION
Svelte.js language is missing and creates an error at workflow.
Color based on GitHub coloring for `Svelte`.

### Related error at workflow

```
Traceback (most recent call last):
despokd
  File "/main.py", line 498, in <module>
Please Ignore this exception 'NoneType' object is not subscriptable
    waka_stats = get_stats(g)
Please Ignore this exception 'NoneType' object is not subscriptable
  File "/main.py", line 455, in get_stats
Please Ignore this exception 'NoneType' object is not subscriptable
    loc.plotLoc(yearly_data)
Please Ignore this exception 'NoneType' object is not subscriptable
  File "/loc.py", line 36, in plotLoc
Exception Occurred 'Svelte'
    graph.build_graph()
  File "/make_bar_graph.py", line 43, in build_graph
    if colors[language]['color'] is not None:
KeyError: 'Svelte'
```