### PR TITLE
option `COMMIT_BY_ME` flag can be set to `True` to commit the code using your name and email

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ jobs:
 
 `LOCALE`  This Flag can be used to show stats in your language default is english uses Locale [Short Hand](https://saimana.com/list-of-country-locale-code/) to be passed in the flag variable example of the final result can be found [here](https://github.com/anmol098/anmol098/blob/master/Readme-fr.md)
 
+`COMMIT_BY_ME`        flag can be set to `True` to commit the code using your name and email
 
 `SHOW_LINES_OF_CODE`       flag can be set to `True` to show the Lines of code writen till date
 

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,10 @@ inputs:
     description: "Show stats in your own language"
     default: "en"
 
+  COMMIT_BY_ME:
+    required: false
+    description: "Git commit with your own name and email"
+    default: "False"
 
 runs:
   using: 'docker'

--- a/main.py
+++ b/main.py
@@ -488,7 +488,7 @@ if __name__ == '__main__':
         username = user_data["data"]["viewer"]["login"]
         email = user_data["data"]["viewer"]["email"]
         id = user_data["data"]["viewer"]["id"]
-        print("Username " + username + ", Email " + email)
+        print("Username " + username)
         repo = g.get_repo(f"{username}/{username}")
         contents = repo.get_readme()
         try:

--- a/main.py
+++ b/main.py
@@ -41,12 +41,14 @@ showLocChart = os.getenv('INPUT_SHOW_LOC_CHART')
 show_profile_view = os.getenv('INPUT_SHOW_PROFILE_VIEWS')
 show_short_info = os.getenv('INPUT_SHOW_SHORT_INFO')
 locale = os.getenv('INPUT_LOCALE')
+commit_by_me = os.getenv('INPUT_COMMIT_BY_ME')
 show_waka_stats = 'y'
 # The GraphQL query to get commit data.
 userInfoQuery = """
 {
     viewer {
       login
+      email
       id
     }
   }
@@ -484,8 +486,9 @@ if __name__ == '__main__':
         headers = {"Authorization": "Bearer " + ghtoken}
         user_data = run_query(userInfoQuery)  # Execute the query
         username = user_data["data"]["viewer"]["login"]
+        email = user_data["data"]["viewer"]["email"]
         id = user_data["data"]["viewer"]["id"]
-        print(username)
+        print("Username " + username + ", Email " + email)
         repo = g.get_repo(f"{username}/{username}")
         contents = repo.get_readme()
         try:
@@ -499,7 +502,10 @@ if __name__ == '__main__':
         # star_me()
         rdmd = decode_readme(contents.content)
         new_readme = generate_new_readme(stats=waka_stats, readme=rdmd)
-        committer = InputGitAuthor('readme-bot', '41898282+github-actions[bot]@users.noreply.github.com')
+        if commit_by_me.lower() in truthy:
+            committer = InputGitAuthor(username, email)
+        else:
+            committer = InputGitAuthor('readme-bot', '41898282+github-actions[bot]@users.noreply.github.com')
         if new_readme != rdmd:
             try:
                 repo.update_file(path=contents.path, message='Updated with Dev Metrics',


### PR DESCRIPTION
If you don't like to use `github-actions[bot]` to commit code,  option `COMMIT_BY_ME` flag can be set to `True` to commit the code using your own name and email