### PR TITLE
feat: add ignored repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ CSS          2 repos        █░░░░░░░░░░░░░░░░�
 
 `SHOW_LOC_CHART`  flag can be set to `False` to hide the Lines of code written in different quarters of different year
 
+`IGNORED_REPOS`  flag can be set to `"waka-readme-stats, my-first-repo"` (just an example) to ignore some repos you don’t want to be counted
+
 **Timeline**
 
 ![Chart not found](https://raw.githubusercontent.com/anmol098/anmol098/master/charts/bar_graph.png) 

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,11 @@ inputs:
     description: "Git commit with your own name and email"
     default: "False"
 
+  IGNORED_REPOS:
+    required: false
+    description: "Repos you don't want to be counted"
+    default: ""
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/loc.py
+++ b/loc.py
@@ -15,20 +15,22 @@ from make_bar_graph import BarGraph
 
 class LinesOfCode:
 
-    def __init__(self, id, username, ghtoken, repositoryData):
+    def __init__(self, id, username, ghtoken, repositoryData, ignored_repos):
         self.id = id
         self.username = username
 
         self.g = Github(ghtoken)
         self.headers = {"Authorization": "Bearer " + ghtoken}
         self.repositoryData = repositoryData
+        self.ignored_repos = ignored_repos
 
     def calculateLoc(self):
         result = self.repositoryData
         yearly_data = {}
         for repo in result['data']['user']['repositories']['edges']:
-            self.getCommitStat(repo['node'], yearly_data)
-            time.sleep(0.7)
+            if repo['node']['name'] not in self.ignored_repos:
+                self.getCommitStat(repo['node'], yearly_data)
+                time.sleep(0.7)
         return yearly_data
 
     def plotLoc(self, yearly_data):

--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ show_profile_view = os.getenv('INPUT_SHOW_PROFILE_VIEWS')
 show_short_info = os.getenv('INPUT_SHOW_SHORT_INFO')
 locale = os.getenv('INPUT_LOCALE')
 commit_by_me = os.getenv('INPUT_COMMIT_BY_ME')
+ignored_repos_name = str(os.getenv('INPUT_IGNORED_REPOS') or '').replace(' ', '').split(',')
 show_waka_stats = 'y'
 # The GraphQL query to get commit data.
 userInfoQuery = """
@@ -387,7 +388,7 @@ def generate_language_per_repo(result):
 
 def get_line_of_code():
     repositoryList = run_query(repositoryListQuery.substitute(username=username, id=id))
-    loc = LinesOfCode(id, username, ghtoken, repositoryList)
+    loc = LinesOfCode(id, username, ghtoken, repositoryList, ignored_repos_name)
     yearly_data = loc.calculateLoc()
     total_loc = sum([yearly_data[year][quarter][lang] for year in yearly_data for quarter in yearly_data[year] for lang in yearly_data[year][quarter]])
     return humanize.intword(int(total_loc))
@@ -453,7 +454,7 @@ def get_stats(github):
         stats = stats + generate_language_per_repo(repositoryList) + '\n\n'
 
     if showLocChart.lower() in truthy:
-        loc = LinesOfCode(id, username, ghtoken, repositoryList)
+        lloc = LinesOfCode(id, username, ghtoken, repositoryList, ignored_repos_name)
         yearly_data = loc.calculateLoc()
         loc.plotLoc(yearly_data)
         stats += '**' + translate['Timeline'] + '**\n\n'

--- a/main.py
+++ b/main.py
@@ -454,7 +454,7 @@ def get_stats(github):
         stats = stats + generate_language_per_repo(repositoryList) + '\n\n'
 
     if showLocChart.lower() in truthy:
-        lloc = LinesOfCode(id, username, ghtoken, repositoryList, ignored_repos_name)
+        loc = LinesOfCode(id, username, ghtoken, repositoryList, ignored_repos_name)
         yearly_data = loc.calculateLoc()
         loc.plotLoc(yearly_data)
         stats += '**' + translate['Timeline'] + '**\n\n'


### PR DESCRIPTION
allow users to customize the ignored repos instead of counting all of them.
how to use:
add `IGNORED_REPOS` in `update-stats.yml` :
```yml
jobs:
  ...
    steps:
        with:
          ...
          IGNORED_REPOS: "waka-readme-stats, my-first-repo"  # separated by commas
```