### PR TITLE
add new symbol for done & empty block v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,12 @@ CSS          2 repos        █░░░░░░░░░░░░░░░░�
 
 `IGNORED_REPOS`  flag can be set to `"waka-readme-stats, my-first-repo"` (just an example) to ignore some repos you don’t want to be counted
 
-`SYMBOL_VERSION` flag can be set to `1` to use █ & ░; set to `2` to use ⣿ & ⣀ for progress bar (default: `1`)
+`SYMBOL_VERSION` flag can be set symbol for progress bar (default: `1`)
+| Version | Done block | Empty block |
+|-------- | ---------- | ----------- |
+|    1    |      █     |       ░     |
+|    2    |      ⣿     |       ⣀     |
+|    3    |      ⬛    |       ⬜    |
 
 **Timeline**
 

--- a/main.py
+++ b/main.py
@@ -180,6 +180,9 @@ def make_graph(percent: float):
     elif (symbol_version == '2'): #version 2
         done_block = '⣿'
         empty_block = '⣀'
+    elif (symbol_version == '3'): # version 3
+        done_block = '⬛'
+        empty_block = '⬜'
     else:
         done_block = '█' #default is version 1
         empty_block = '░'


### PR DESCRIPTION
Hi, I'm Lil Huy. Today I want to contribute a pull request.
I've found new pair of symbols for the progress bar, which causes no height difference between the 2 symbols of the progress bar.
I tested them and it seems to work for both Windows, Linux, and mobile.

**Old PR**: #266

**New pair of symbols**
![image](https://user-images.githubusercontent.com/69106844/157398916-1de7fec8-4c2c-4350-884d-d63bb7b6f63b.png)
Can you help me test? @aravindvnair99

I hope to accept this pull request. Thanks.