### PR TITLE
Add last updated date format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ![Project Preview](https://user-images.githubusercontent.com/25841814/79395484-5081ae80-7fac-11ea-9e27-ac91472e31dd.png)
 
 <p align="center">
-  
+
   ![Project Preview](https://user-images.githubusercontent.com/15426564/88030180-8e1c4780-cb58-11ea-8a8b-b3576dd73652.png)
-  
+
   <h3 align="center">📌✨Awesome Readme Stats</h3>
 </p>
 
@@ -124,6 +124,8 @@ jobs:
 `COMMIT_MESSAGE`        flag can be to set message commit, default is "Updated with Dev Metrics"
 
 `SHOW_UPDATED_DATE`        flag can be set to `True` to show updated date in end of paragraph
+
+`UPDATED_DATE_FORMAT`        flag can be set to put updated date into a format, default is `"%d/%m/%Y %H:%M:%S"`
 
 `SHOW_LINES_OF_CODE`       flag can be set to `True` to show the Lines of code writen till date
 

--- a/action.yml
+++ b/action.yml
@@ -97,6 +97,11 @@ inputs:
     description: "Show updated date"
     default: "True"
 
+  UPDATED_DATE_FORMAT:
+    required: false
+    description: "Updated date format"
+    default: "%d/%m/%Y %H:%M:%S"
+
   SHOW_TOTAL_CODE_TIME:
     required: false
     description: "Show Total Time you have coded"

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ locale = os.getenv('INPUT_LOCALE')
 commit_by_me = os.getenv('INPUT_COMMIT_BY_ME')
 ignored_repos_name = str(os.getenv('INPUT_IGNORED_REPOS') or '').replace(' ', '').split(',')
 show_updated_date = os.getenv('INPUT_SHOW_UPDATED_DATE')
+updated_date_format = os.getenv('INPUT_UPDATED_DATE_FORMAT')
 commit_message = os.getenv('INPUT_COMMIT_MESSAGE')
 show_total_code_time = os.getenv('INPUT_SHOW_TOTAL_CODE_TIME')
 symbol_version = os.getenv('INPUT_SYMBOL_VERSION').strip()
@@ -518,7 +519,7 @@ def get_stats(github):
 
     if show_updated_date.lower() in truthy:
         now = datetime.datetime.utcnow()
-        d1 = now.strftime("%d/%m/%Y %H:%M:%S")
+        d1 = now.strftime(updated_date_format)
         stats = stats + "\n Last Updated on " + d1 + " UTC"
 
     return stats


### PR DESCRIPTION
When I switch on the SHOW_UPDATED_DATE option, 

I see the last updated time displayed like `29/03/2022`.

It is not a Chinese habitual expression of dates. We prefer `2022/03/29` .

Thus I add a flag to format the date.
