### PR TITLE
Added SHOW_TOTAL_CODE_TIME flag to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ jobs:
 
 ![Lines of code](https://img.shields.io/badge/From%20Hello%20World%20I've%20written-1.3%20million%20Lines%20of%20code-blue)
 
+`SHOW_TOTAL_CODE_TIME`       flag can be set to `False` to hide *Code Time*
+
+![Code Time](http://img.shields.io/badge/Code%20Time-1%2C438%20hrs%2054%20mins-blue)
+
 `SHOW_PROFILE_VIEWS`       flag can be set to `False` to hide the Profile views
 
 ![Profile Views](http://img.shields.io/badge/Profile%20Views-2189-blue)


### PR DESCRIPTION
This update adds the `SHOW_TOTAL_CODE_TIME` flag to the README.md file.

This feature already works, I am just adding the documentation so others can use it.

Once merged, I will close this issue: https://github.com/anmol098/waka-readme-stats/issues/248