### PR TITLE
Fix #338 - Duplicate `COMMIT_USERNAME` and `COMMIT_EMAIL` in `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,16 +106,6 @@ inputs:
     required: false
     description: "Git commit custom email"
     default: ""
-  
-  COMMIT_USERNAME:
-    required: false
-    description: "Git commit custom username"
-    default: ""
-
-  COMMIT_EMAIL:
-    required: false
-    description: "Git commit custom email"
-    default: ""
 
   SHOW_UPDATED_DATE:
     required: false


### PR DESCRIPTION
Fixes #338

## Proposed Changes

- Remove duplicate `COMMIT_USERNAME` and `COMMIT_EMAIL` in `action.yml`