### PR TITLE
NPM update removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ ENV PATH "$PATH:/home/root/.npm-global/bin"
 RUN python -m pip install --upgrade pip wheel setuptools
 RUN pip install -r requirements.txt
 RUN npm -g config set user root
-RUN npm i -g npm@latest
 RUN npm i -g vega vega-lite vega-cli canvas
 
 ENTRYPOINT ["python", "/main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV PATH "$PATH:/home/root/.npm-global/bin"
 RUN python -m pip install --upgrade pip wheel setuptools
 RUN pip install -r requirements.txt
 RUN npm -g config set user root
+RUN npm i -g npm@next-8
 RUN npm i -g vega vega-lite vega-cli canvas
 
 ENTRYPOINT ["python", "/main.py"]


### PR DESCRIPTION
NPM update removed [because of breaking changes introduced in NPMv9](https://github.com/altair-viz/altair_saver/issues/113), NPMv8 is provided with container [by default](https://hub.docker.com/r/nikolaik/python-nodejs). Solves #337.