### PR TITLE
Fix https://github.com/anmol098/waka-readme-stats/issues/358

### DIFF
--- a/main.py
+++ b/main.py
@@ -201,9 +201,10 @@ def make_list(data: list):
     for l in data[:5]:
         ln = len(l['name'])
         ln_text = len(l['text'])
-        op = f"{l['name'][:25]}{' ' * (25 - ln)}{l['text']}{' ' * (20 - ln_text)}{make_graph(l['percent'])}   {l['percent']}%"
+        percent = "{:05.2f}".format(float(l['percent']))
+        op = f"{l['name'][:25]}{' ' * (25 - ln)}{l['text']}{' ' * (20 - ln_text)}{make_graph(l['percent'])}   {percent} % "
         data_list.append(op)
-    return ' \n'.join(data_list)
+    return '\n'.join(data_list)
 
 
 def make_commit_list(data: list):
@@ -212,9 +213,10 @@ def make_commit_list(data: list):
     for l in data[:7]:
         ln = len(l['name'])
         ln_text = len(l['text'])
-        op = f"{l['name']}{' ' * (13 - ln)}{l['text']}{' ' * (15 - ln_text)}{make_graph(l['percent'])}   {l['percent']}%"
+        percent = "{:05.2f}".format(float(l['percent']))
+        op = f"{l['name']}{' ' * ((15 - ln) + (13 - ln_text))}{l['text']}{' ' * (7)}{make_graph(l['percent'])}   {percent} % "
         data_list.append(op)
-    return ' \n'.join(data_list)
+    return '\n'.join(data_list)
 
 
 def generate_commit_list(tz):


### PR DESCRIPTION
This hopefully does fix https://github.com/anmol098/waka-readme-stats/issues/358

Tested on my readme and it works like a charm, hopefully i didn't break something else :D
You may want to adjust the spacing before and after the "commit" as i've widened the gap a bit -> `op = f"{l['name']}{' ' * ((15 - ln) + (13 - ln_text))}{l['text']}{' ' * (7)}{make_graph(l['percent'])}   {percent} % "`

Readme before:
![image](https://user-images.githubusercontent.com/50703696/216948600-67948bda-fc2f-4c0c-b541-804052bbe071.png)

Readme after:
![image](https://user-images.githubusercontent.com/50703696/216948696-f5eb2587-ef15-4515-b12c-d833c3341833.png)

Live example running here https://github.com/infinitel8p/infinitel8p