### PR TITLE
Fix FileNotFoundError

### DIFF
--- a/sources/manager_file.py
+++ b/sources/manager_file.py
@@ -28,7 +28,7 @@ class FileManager:
 
         :param file: Localization file path, related to current file (in sources root).
         """
-        with open(join("sources", file), encoding="utf-8") as config_file:
+        with open(file, encoding="utf-8") as config_file:
             data = load(config_file)
         FileManager._LOCALIZATION = data[EM.LOCALE]
 


### PR DESCRIPTION
Fix #398

## Test

I wrote a smoke test as following.

```py
import os

os.environ["INPUT_GH_TOKEN"] = ""
os.environ["INPUT_WAKATIME_API_KEY"] = ""
os.environ["INPUT_SYMBOL_VERSION"] = "1"

from manager_file import FileManager


FileManager.load_localization("translation.json")
```

before this change
```sh
$ python test_manager_file.py

Traceback (most recent call last):
  File "/Users/haruki-kitagawa/ghq/github.com/kitagawa-hr/waka-readme-stats/sources/test_manager_file.py", 
line 11, in <module>
    FileManager.load_localization("translation.json")
  File "/Users/haruki-kitagawa/ghq/github.com/kitagawa-hr/waka-readme-stats/sources/manager_file.py", line 
31, in load_localization
    with open(join("sources", file), encoding="utf-8") as config_file:
FileNotFoundError: [Errno 2] No such file or directory: 'sources/translation.json'

```

after

```sh
$ python test_manager_file.py


```
