### PR TITLE
Update Readme.md to remove ambiguity for personal token creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 1. You need to update the markdown file(.md) with 2 comments. You can refer [here](#update-your-readme) for updating it.
 2. You'll need a WakaTime API Key. You can get that from your WakaTime Account Settings
     - You can refer [here](#new-to-wakatime), if you're new to WakaTime
-3. You'll need a GitHub API Token with `repo` and `user` scope from [here](https://github.com/settings/tokens) if you're running the action to get commit metrics
+3. You'll need a GitHub API Token with `repo` and `user` scope created with option `Generate new token (classic) For general use` from [here](https://github.com/settings/tokens) if you're running the action to get commit metrics
    > enabling the `repo` scope seems **DANGEROUS**<br/>
    > but this GitHub Action only accesses your commit timestamp and lines of code added or deleted in repository you contributed.
    - You can use [this](#profile-repository) example to work it out


### PR DESCRIPTION
There has been recent change in the ways to create GitHub API token. Earlier there was only one option to create token but now with the recent change one more option is added i.e. Generate new token (Fine-grained, repo-scoped).  The current documentation assumes we are creating a token with earlier option i.e. Generate new token (For general use) and thus says "You'll need a GitHub API Token with repo and user scope...". With the advent of new option this is invalid.  Hence we need to specify in the Readme.md file to create the token using previous option only. This commit updates that.