### PR TITLE
Fixed TypeError when contributed_node is being None.

### DIFF
--- a/sources/main.py
+++ b/sources/main.py
@@ -133,7 +133,7 @@ async def collect_user_repositories() -> Dict:
     DBM.g("\tUser repository list collected!")
 
     contributed = await DM.get_remote_graphql("repos_contributed_to", username=GHM.USER.login)
-    contributed_nodes = [r for r in contributed["data"]["user"]["repositoriesContributedTo"]["nodes"] if r["name"] not in repo_names and not r["isFork"]]
+    contributed_nodes = [r for r in contributed["data"]["user"]["repositoriesContributedTo"]["nodes"] if r and r["name"] not in repo_names and not r["isFork"]]
     DBM.g("\tUser contributed to repository list collected!")
 
     repositories["data"]["user"]["repositories"]["nodes"] += contributed_nodes


### PR DESCRIPTION
Fix another `TypeError: 'NoneType' object is not subscriptable` in `main.update_data_with_commit_stats()`:

```
...
  File "/waka-readme-stats/main.py", line 136, in <listcomp>
    contributed_nodes = [r for r in contributed["data"]["user"]["repositoriesContributedTo"]["nodes"] if r["name"] not in repo_names and not r["isFork"]]
                                                                                                         ~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
sys:1: RuntimeWarning: coroutine 'AsyncClient.get' was never awaited
```

Could relate to https://github.com/anmol098/waka-readme-stats/issues/463