### PR TITLE
Fixed `RuntimeWarning`

### DIFF
--- a/sources/manager_download.py
+++ b/sources/manager_download.py
@@ -151,7 +151,7 @@ class DownloadManager:
         :param resources: Static queries, formatted like "IDENTIFIER"="URL".
         """
         for resource, url in resources.items():
-            DownloadManager._REMOTE_RESOURCES_CACHE[resource] = DownloadManager._client.get(url)
+            DownloadManager._REMOTE_RESOURCES_CACHE[resource] = await DownloadManager._client.get(url)
 
     @staticmethod
     async def close_remote_resources():


### PR DESCRIPTION
Fixed the bug mentioned in the [issue 523](https://github.com/anmol098/waka-readme-stats/issues/523) which was `sys:1: RuntimeWarning: coroutine 'AsyncClient.get' was never awaited`