### PR TITLE
Fix header formatting by adding missing line breaks in markdown rendering

### DIFF
--- a/sources/main.py
+++ b/sources/main.py
@@ -29,6 +29,7 @@ async def get_waka_time_stats(repositories: Dict, commit_dates: Dict) -> str:
     """
     DBM.i("Adding short WakaTime stats...")
     stats = str()
+    stats+=f"  \n";
 
     data = await DM.get_remote_json("waka_latest")
     if data is None:


### PR DESCRIPTION
Fix markdown formatting display issues in specific scenarios where a line break was missing before the first-line header.