### PR TITLE
fix: update PUBLISH_IMAGE workflow

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -14,20 +14,20 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx 🐋
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the container registry 🚪
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: wakareadmestats
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker 🏋️
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: wakareadmestats/waka-readme-stats
           tags: |
@@ -37,7 +37,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker image 🏗️
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/releases') }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
So this is why the Action was failing. It was failing to publish as it couldn't pull actions/checkout@v4.
Should close #582.