### PR TITLE
Set lines of code formating to two decimal places

### DIFF
--- a/sources/main.py
+++ b/sources/main.py
@@ -181,7 +181,7 @@ async def get_stats() -> str:
     if EM.SHOW_LINES_OF_CODE:
         DBM.i("Adding lines of code info...")
         total_loc = sum([yearly_data[y][q][d]["add"] for y in yearly_data.keys() for q in yearly_data[y].keys() for d in yearly_data[y][q].keys()])
-        data = f"{intword(total_loc)} {FM.t('Lines of code')}"
+        data = f"{intword(total_loc, format='%.2f')} {FM.t('Lines of code')}"
         stats += f"![Lines of code](https://img.shields.io/badge/{quote(FM.t('From Hello World I have written'))}-{quote(data)}-blue)\n\n"
 
     if EM.SHOW_SHORT_INFO:


### PR DESCRIPTION
Improve accuracy by increasing the number of decimal places from 1 to 2 for numeric word format.