### PR TITLE
Use specific username for the GitHub part of CI

### DIFF
--- a/.github/workflows/ci_PR.yml
+++ b/.github/workflows/ci_PR.yml
@@ -84,7 +84,7 @@ jobs:
 
           INPUT_GH_TOKEN: ${{ github.token }}
           # Generate stats for the PR author
-          INPUT_GH_USER: ${{ github.event.pull_request.user.login }}
+          INPUT_GH_USER: pseusys
 
           INPUT_SYMBOL_VERSION: 1
           INPUT_SHOW_TIMEZONE: True


### PR DESCRIPTION
Due to some people having contributed to very large repos: see this https://github.com/anmol098/waka-readme-stats/actions/runs/30833596520/job/91753309815?pr=502

This changes from using PR author to `pseusys`, whos' workflow takes a short time to finish.