### PR TITLE
fix: remove expression syntax from PUSH_TOKEN description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: ${{ github.token }}
 
   PUSH_TOKEN:
-    description: 'GitHub token used for git authentication (clone/remote URL/push). To prevent polluting your activity feed, set this to `${{ github.token }}` and ensure your workflow has `permissions: contents: write`.'
+    description: 'GitHub token used for git authentication (clone/remote URL/push). To prevent polluting your activity feed, pass the workflow GitHub token and ensure your workflow has contents write permission.'
     required: false
     default: ${{ github.token }}
 


### PR DESCRIPTION
This PR fixes the action loading failure introduced by #654.

The `PUSH_TOKEN` description included the literal expression `${{ github.token }}`. GitHub Actions attempted to evaluate it while parsing `action.yml`, which caused the action to fail before any steps could run:

```text
Unrecognized named-value: 'github'
```

## Fix

The description has been rewritten without the `${{ ... }}` expression syntax.

The existing `PUSH_TOKEN` default and fallback behavior remain unchanged.

## Impact

Workflows using `anmol098/waka-readme-stats@master` should be able to load and run normally again after this fix is merged.

## Apology

I apologize for introducing this regression in #654 and for not catching the metadata parsing issue before the PR was merged.

Thank you to everyone affected for your patience. I have kept this fix intentionally small so it can be reviewed and merged quickly.

## Reproduction

The failure can be reproduced in this workflow run:

https://github.com/zryyyy/zryyyy/actions/runs/30860522709/job/91841266962
