### PR TITLE
Fix LOC chart after Linguist renamed Vim Script to Vim script

### DIFF
--- a/sources/graphics_chart_drawer.py
+++ b/sources/graphics_chart_drawer.py
@@ -22,6 +22,7 @@ async def create_loc_graph(yearly_data: Dict, save_path: str):
     colors = await DM.get_remote_yaml("linguist")
     if colors is None:
         colors = dict()
+    colors = {k.casefold(): v for k, v in colors.items()}
     years = len(yearly_data.keys())
     year_indexes = np.arange(years)
 
@@ -42,7 +43,7 @@ async def create_loc_graph(yearly_data: Dict, save_path: str):
     cumulative = np.zeros((years, 4, 2), dtype=int)
 
     for key, value in languages_all_loc.items():
-        color = colors[key].get("color", "tab:gray")
+        color = colors[key.casefold()].get("color", "tab:gray")
         language_handles += [mpatches.Patch(color=color, label=key)]
 
         for quarter in range(4):


### PR DESCRIPTION
GitHub Linguist renamed `Vim Script` to `Vim script` in github-linguist/linguist#8124.

`waka-readme-stats` uses the language name returned by the GitHub API as a case-sensitive key for Linguist's [languages.yml](https://cdn.jsdelivr.net/gh/github/linguist@master/lib/linguist/languages.yml), causing:

```text
KeyError: 'Vim Script'
```

This change normalizes language names with casefold() before color lookup.