### PR TITLE
Fix (make_list): sort before slice + add SHOW_LANGUAGE_COUNT option

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ The `SHOW_COMMIT` flag can be set to `False` to hide the commit stats.
 **I'm an early 🐤**
 
 ```text
-🌞 Morning    95 commits     ███████░░░░░░░░░░░░░░░░░░   30.55% 
-🌆 Daytime    78 commits     ██████░░░░░░░░░░░░░░░░░░░   25.08% 
-🌃 Evening    112 commits    █████████░░░░░░░░░░░░░░░░   36.01% 
+🌞 Morning    95 commits     ███████░░░░░░░░░░░░░░░░░░   30.55%
+🌆 Daytime    78 commits     ██████░░░░░░░░░░░░░░░░░░░   25.08%
+🌃 Evening    112 commits    █████████░░░░░░░░░░░░░░░░   36.01%
 🌙 Night      26 commits     ██░░░░░░░░░░░░░░░░░░░░░░░   8.36%
 
 ```
@@ -222,17 +222,19 @@ The `SHOW_DAYS_OF_WEEK` flag can be set to `False` to hide the commits made on t
 📅 **I'm Most Productive on Sundays**
 
 ```text
-Monday       50 commits     ███░░░░░░░░░░░░░░░░░░░░░░   13.19% 
-Tuesday      85 commits     █████░░░░░░░░░░░░░░░░░░░░   22.43% 
-Wednesday    56 commits     ███░░░░░░░░░░░░░░░░░░░░░░   14.78% 
-Thursday     44 commits     ███░░░░░░░░░░░░░░░░░░░░░░   11.61% 
-Friday       28 commits     █░░░░░░░░░░░░░░░░░░░░░░░░   7.39% 
-Saturday     30 commits     ██░░░░░░░░░░░░░░░░░░░░░░░   7.92% 
+Monday       50 commits     ███░░░░░░░░░░░░░░░░░░░░░░   13.19%
+Tuesday      85 commits     █████░░░░░░░░░░░░░░░░░░░░   22.43%
+Wednesday    56 commits     ███░░░░░░░░░░░░░░░░░░░░░░   14.78%
+Thursday     44 commits     ███░░░░░░░░░░░░░░░░░░░░░░   11.61%
+Friday       28 commits     █░░░░░░░░░░░░░░░░░░░░░░░░   7.39%
+Saturday     30 commits     ██░░░░░░░░░░░░░░░░░░░░░░░   7.92%
 Sunday       86 commits     █████░░░░░░░░░░░░░░░░░░░░   22.69%
 
 ```
 
 The `SHOW_LANGUAGE` flag can be set to `False` to hide the programming languages you use.
+
+The `SHOW_LANGUAGE_COUNT` option controls how many languages are shown in the Languages section (default: `5`, minimum: `1`). For example, set it to `8` to show your top 8 languages instead of the default 5.
 
 ```text
 💬 Languages:
@@ -281,12 +283,12 @@ The `SHOW_LANGUAGE_PER_REPO` flag can be set to `False` to hide the number of re
 **I mostly code in Vue**
 
 ```text
-Vue          8 repos        ██████░░░░░░░░░░░░░░░░░░░   25.0% 
-Java         6 repos        ████░░░░░░░░░░░░░░░░░░░░░   18.75% 
-JavaScript   6 repos        ████░░░░░░░░░░░░░░░░░░░░░   18.75% 
-PHP          3 repos        ██░░░░░░░░░░░░░░░░░░░░░░░   9.38% 
-Python       2 repos        █░░░░░░░░░░░░░░░░░░░░░░░░   6.25% 
-Dart         2 repos        █░░░░░░░░░░░░░░░░░░░░░░░░   6.25% 
+Vue          8 repos        ██████░░░░░░░░░░░░░░░░░░░   25.0%
+Java         6 repos        ████░░░░░░░░░░░░░░░░░░░░░   18.75%
+JavaScript   6 repos        ████░░░░░░░░░░░░░░░░░░░░░   18.75%
+PHP          3 repos        ██░░░░░░░░░░░░░░░░░░░░░░░   9.38%
+Python       2 repos        █░░░░░░░░░░░░░░░░░░░░░░░░   6.25%
+Dart         2 repos        █░░░░░░░░░░░░░░░░░░░░░░░░   6.25%
 CSS          2 repos        █░░░░░░░░░░░░░░░░░░░░░░░░   6.25%
 
 ```
@@ -433,107 +435,107 @@ Please share any features, and add unit tests! Use the pull request and issue sy
 <summary>Special mention for those who are currently making their profile readme more awesome :smile: :tada:</summary>
 
 - [Stanislas](https://github.com/angristan)
-  
+
 - [Pratik Kumar](https://github.com/pr2tik1)
-  
+
 - [Vladimir](https://github.com/sergeev-vn)
 
 - [Pedro Torres](https://github.com/Corfucinas)
-  
+
 - [leverglowh](https://github.com/leverglowh)
-  
+
 - [patdc](https://github.com/patdc)
-  
+
 - [极客挖掘机](https://github.com/meteor1993)
-  
+
 - [Fan()](https://github.com/Fanduzi)
-  
+
 - [Miller Camilo Vega](https://github.com/minoveaz)
-  
+
 - [XLor](https://github.com/yjl9903)
-  
+
 - [Jesse Okeya](https://github.com/jesseokeya)
-  
+
 - [anaiel](https://github.com/anaiel)
-  
+
 - [Dipto Mondal](https://github.com/diptomondal007)
-  
+
 - [Jerry F. Zhang](https://github.com/JerryFZhang)
-  
+
 - [Karan Singh](https://github.com/karan06126)
-  
+
 - [Erwin Lejeune](https://github.com/guilyx)
-  
+
 - [Manuel Cepeda](https://github.com/mecm1993)
-  
+
 - [Jonathan S](https://github.com/TGTGamer)
-  
+
 - [Tsotne Gvadzabia](https://github.com/RockiRider)
-  
+
 - [Miray](https://github.com/MirayXS)
-  
+
 - [Varad Patil](https://github.com/varadp2000)
-  
+
 - [Prabhat Singh](https://github.com/prabhatdev)
-  
+
 - [Nikhil](https://github.com/nikhilgorantla)
-  
+
 - [大白](https://github.com/2720851545)
-  
+
 - [Du Yizhuo](https://github.com/dyzdyz010)
-  
+
 - [Manas Talukdar](https://github.com/manastalukdar)
-  
+
 - [Simranjeet Singh](https://github.com/smrnjeet222)
-  
+
 - [Aaron Meese](https://github.com/ajmeese7)
-  
+
 - [Prasad Narkhede](https://github.com/p014ri5)
-  
+
 - [Manish Kushwaha](https://github.com/tzmanish)
-  
+
 - [Hedy Li](https://github.com/hedythedev)
-  
+
 - [SHIMIZU Taku](https://github.com/takuan-osho)
-  
+
 - [Jude Wilson](https://github.com/mr-winson)
-  
+
 - [Daniel Rowe](https://github.com/DanRowe)
-  
+
 - [Muhammad Hassan Ahmed](https://github.com/hassan11196)
-  
+
 - [Alessandro Maggio](https://github.com/Tkd-Alex)
-  
+
 - [Siddharth Gupta](https://github.com/siddg97)
-  
+
 - [Dev-Mehta](https://github.com/Dev-Mehta/)
-  
+
 - [> EdgyCoder ✌](https://github.com/edgycoder)
-  
+
 - [Korel Kashri](https://github.com/korelkashri)
-  
+
 - [Gustavo Barbosa](https://github.com/gusbdev)
 
 - [eagleanurag](https://github.com/eagleanurag)
-  
+
 - [Aravind V. Nair](https://github.com/aravindvnair99)
-  
+
 - [Raman Preet Singh](https://github.com/raman08)
-  
+
 - [Hayat Tamboli](https://github.com/hayat-tamboli)
-  
+
 - [Henry Boisdequin](https://github.com/henryboisdequin)
 
 - [Raman Preet Singh](https://github.com/raman08)
-  
+
 - [Aadit Kamat](https://github.com/aaditkamat)
 
 - [Subhalingam D](https://github.com/subhalingamd)
-  
+
 - [Adil Akhmetov](https://github.com/weeebdev)
-  
+
 - [Isaac Maldonado](https://github.com/einjunge99)
-  
+
 - [Syed Faateh Sultan Kazmi](https://github.com/faatehsultan)
 
 - [Shreyam Maity](https://github.com/ShreyamMaity)
@@ -543,13 +545,13 @@ Please share any features, and add unit tests! Use the pull request and issue sy
 - [Muhammad Bilal](https://github.com/BilalJaved15)
 
 - [Waterdev](https://github.com/UnrealValentin)
-  
+
 - [Aditya Prasad S](https://github.com/adityaprasad502)
-  
+
 - [C. Vinicius Santos](https://github.com/c-viniciussantos)
-  
+
 - [James Tufarelli](https://github.com/Minituff)
-  
+
 - [Muhammad Bilal](https://github.com/BilalJaved15)
 
 - [Wyatt Walsh](https://www.github.com/wyattowalsh)

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   WAKATIME_API_KEY:
     description: 'Your Wakatime API Key'
     required: true
-  
+
   WAKATIME_API_URL:
     description: 'Your Wakatime API URL'
     required: false
@@ -121,7 +121,7 @@ inputs:
     required: false
     description: "Git commit with your own name and email"
     default: "False"
-  
+
   COMMIT_MESSAGE:
     required: false
     description: "Git commit message"
@@ -131,7 +131,7 @@ inputs:
     required: false
     description: "Git commit custom username"
     default: ""
-  
+
   COMMIT_EMAIL:
     required: false
     description: "Git commit custom email"
@@ -166,6 +166,11 @@ inputs:
     required: false
     description: "(Deprecated) Alias for MAX_REPOS"
     default: "0"
+
+  SHOW_LANGUAGE_COUNT:
+    required: false
+    description: "Number of languages to show in the languages section (default: 5, minimum: 1)"
+    default: "5"
 
   SYMBOL_VERSION:
     required: false

--- a/sources/graphics_chart_drawer.py
+++ b/sources/graphics_chart_drawer.py
@@ -6,7 +6,6 @@ import matplotlib.pyplot as plt
 from manager_download import DownloadManager as DM
 from manager_file import FileManager as FM
 
-
 MAX_LANGUAGES = 5  # Number of top languages to add to chart, for each year quarter
 GRAPH_PATH = f"{FM.ASSETS_DIR}/bar_graph.png"  # Chart saving path.
 

--- a/sources/graphics_list_formatter.py
+++ b/sources/graphics_list_formatter.py
@@ -8,7 +8,6 @@ from pytz import timezone, utc
 from manager_environment import EnvironmentManager as EM
 from manager_file import FileManager as FM
 
-
 DAY_TIME_EMOJI = ["🌞", "🌆", "🌃", "🌙"]  # Emojis, representing different times of day.
 DAY_TIME_NAMES = ["Morning", "Daytime", "Evening", "Night"]  # Localization identifiers for different times of day.
 WEEK_DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]  # Localization identifiers for different days of week.
@@ -73,7 +72,7 @@ def make_list(data: List = None, names: List[str] = None, texts: List[str] = Non
         percents = [value for item in data for key, value in item.items() if key == "percent"] if percents is None else percents
 
     data = list(zip(names, texts, percents))
-    top_data = sorted(data[:top_num], key=lambda record: record[2], reverse=True) if sort else data[:top_num]
+    top_data = sorted(data, key=lambda record: record[2], reverse=True)[:top_num] if sort else data[:top_num]
 
     if EM.BAR_STYLE == "svg":
         # Fixed column layout (widths in user units; total view width = sum of columns + trailing margin):

--- a/sources/main.py
+++ b/sources/main.py
@@ -157,7 +157,7 @@ async def get_waka_time_stats(repositories: Dict, commit_dates: Dict) -> str:
 
         if EM.SHOW_LANGUAGE:
             DBM.i("Adding user top languages info...")
-            lang_list = no_activity if len(data["data"]["languages"]) == 0 else make_list(data["data"]["languages"])
+            lang_list = no_activity if len(data["data"]["languages"]) == 0 else make_list(data["data"]["languages"], top_num=EM.SHOW_LANGUAGE_COUNT)
             stats += f"💬 {FM.t('Languages')}: \n{lang_list}\n\n"
 
         if EM.SHOW_EDITORS:

--- a/sources/manager_environment.py
+++ b/sources/manager_environment.py
@@ -8,7 +8,7 @@ class EnvironmentManager:
     The others have a provided default value.
     For all boolean variables a 'truthy'-list is checked (not only true/false, but also 1, t, y and yes are accepted).
     List variable `IGNORED_REPOS` is split and parsed.
-    Integer variables `SYMBOL_VERSION` and `MAX_REPOS` are parsed.
+    Integer variables `SYMBOL_VERSION`, `MAX_REPOS` and `SHOW_LANGUAGE_COUNT` are parsed.
     """
 
     _TRUTHY = ["true", "1", "t", "y", "yes"]
@@ -71,6 +71,12 @@ class EnvironmentManager:
     MAX_REPOS = int(_raw_repo_cap) if _raw_repo_cap else 0
     if MAX_REPOS < 0:
         MAX_REPOS = 0
+
+    _raw_show_language_count = getenv("INPUT_SHOW_LANGUAGE_COUNT", "5").strip()
+    SHOW_LANGUAGE_COUNT = int(_raw_show_language_count) if _raw_show_language_count.lstrip("-").isdigit() else 5
+    if SHOW_LANGUAGE_COUNT < 1:
+        SHOW_LANGUAGE_COUNT = 1
+
     SYMBOL_VERSION = int(getenv("INPUT_SYMBOL_VERSION", "1"))
     BADGE_STYLE = getenv("INPUT_BADGE_STYLE") or getenv("BADGE_STYLE", "flat")
     BAR_STYLE = (getenv("INPUT_BAR_STYLE") or getenv("BAR_STYLE", "text")).strip()  # "text" or "svg"


### PR DESCRIPTION
Closes #681

## What this PR does

Two related fixes to the language-stats rendering logic in `make_list`.

### 1. Fix sort-before-slice bug (`sources/graphics_list_formatter.py`)

**Root cause:** `make_list` was slicing to `top_num` entries _before_ sorting by percent:

```python
# Before (buggy)
top_data = sorted(data[:top_num], key=lambda record: record[2], reverse=True) if sort else data[:top_num]
```

This means languages that appear beyond position `top_num` in the WakaTime API response are silently dropped — even if they have a higher usage percentage — while lower-ranked ones near the start of the array are kept and shown instead.

Fix: Sort the full dataset first, then slice:

```python
# After (correct)
top_data = sorted(data, key=lambda record: record[2], reverse=True)[:top_num] if sort else data[:top_num]
```

Callers that pass `sort=False` (e.g. `make_commit_day_time_list`, `make_language_per_repo_list`) are unaffected by this change.

### 2. Add `SHOW_LANGUAGE_COUNT` configuration option

The issue notes that `top_num` for the Languages: section is hardcoded (default 5) with no way for users to override it. This PR also addresses that:

- `sources/manager_environment.py` — parses `INPUT_SHOW_LANGUAGE_COUNT` as an integer (default 5, minimum 1; invalid values fall back gracefully), following the same `_raw_*` → `int()` → clamp pattern used by `MAX_REPOS`.
- `sources/main.py` — passes `top_num=EM.SHOW_LANGUAGE_COUNT` to `make_list()` in `get_waka_time_stats()`.
- `action.yml` — declares the new `SHOW_LANGUAGE_COUNT` input (default "5"), placed alongside the other `MAX_REPOS`-style options.
- `README.md` — documents `SHOW_LANGUAGE_COUNT` in the same section as `SHOW_LANGUAGE`.